### PR TITLE
Fix func test target name identification

### DIFF
--- a/openstack/tools/func_test_tools/common.py
+++ b/openstack/tools/func_test_tools/common.py
@@ -23,12 +23,7 @@ class OSCIConfig():
             if 'check' not in item['project']:
                 continue
 
-            for job in item['project']['check'].get('jobs', []):
-                # can be a dict with voting info
-                if isinstance(job, dict):
-                    yield list(job.keys())[0]
-                else:
-                    yield job
+            yield from item['project']['check'].get('jobs', [])
 
     @property
     def jobs(self):
@@ -36,6 +31,17 @@ class OSCIConfig():
         for item in self._osci_config:
             if 'job' in item:
                 yield item['job']
+
+    def get_job(self, name):
+        """ Get job by name.
+
+        @param name: string name
+        """
+        for job in self.jobs:
+            if job['name'] == name:
+                return job
+
+        return None
 
 
 class ProjectTemplatesConfig():

--- a/openstack/tools/func_test_tools/extract_job_target.py
+++ b/openstack/tools/func_test_tools/extract_job_target.py
@@ -1,0 +1,33 @@
+"""
+If a job has an accompanying vars section that specifies a tox command with
+target names we need to run those instead of the job name.
+"""
+import re
+import sys
+
+from common import OSCIConfig  # pylint: disable=import-error
+
+
+def extract_job_target(testjob):
+    """
+    Some jobs map directly to target names and some needs to be de-refenced by
+    looking for the job definition and extracting the target from the tox
+    command. Returns jobname if no dereference available.
+
+    @param job: job name
+    """
+    osci = OSCIConfig()
+    job = osci.get_job(testjob)
+    if not job or 'vars' not in job or 'tox_extra_args' not in job['vars']:
+        return testjob
+
+    ret = re.search(r"-- (.+)",
+                    str(job['vars']['tox_extra_args']))
+    if not ret:
+        return testjob
+
+    return ret.group(1)
+
+
+if __name__ == "__main__":
+    print(extract_job_target(sys.argv[1]))

--- a/openstack/tools/func_test_tools/test_is_voting.py
+++ b/openstack/tools/func_test_tools/test_is_voting.py
@@ -14,7 +14,7 @@ from common import (  # pylint: disable=import-error
 
 
 if __name__ == "__main__":
-    target_name = sys.argv[1]
+    test_job = sys.argv[1]
     zosci_path = os.path.join(os.environ['HOME'], "zosci-config")
     project_templates = os.path.join(zosci_path,
                                      "zuul.d/project-templates.yaml")
@@ -25,19 +25,17 @@ if __name__ == "__main__":
         osci_config = OSCIConfig()
         try:
             jobs = osci_config.project_check_jobs
-            if target_name in jobs:
-                # default is voting=True
-                sys.exit(0)
-
-            for check in jobs:
-                if isinstance(check, dict) and target_name in check:
-                    if not check[target_name]['voting']:
+            for job in jobs:
+                if isinstance(job, dict) and test_job in job:
+                    if not job[test_job]['voting']:
                         sys.exit(1)
                     else:
+                        # default is true
                         sys.exit(0)
+
         except KeyError as exc:
             sys.stderr.write(f"ERROR: failed to process osci.yaml - assuming "
-                             f"{target_name} is voting (key {exc} not found)."
+                             f"{test_job} is voting (key {exc} not found)."
                              "\n")
 
     # If the target was not found in osci.yaml then osci will fallback to
@@ -47,6 +45,6 @@ if __name__ == "__main__":
         for project in config.project_templates:
             if project['name'] == "charm-functional-jobs":
                 for job in project['check']['jobs']:
-                    if target_name in job:
-                        if not job[target_name].get('voting', True):
+                    if test_job in job:
+                        if not job[test_job].get('voting', True):
                             sys.exit(1)


### PR DESCRIPTION
We first need to identify jobs and maintain that list as-is since voting info uses job names. We then
de-reference jobs where needed at the last minute to extract e.g. aliased targets that use overlays.