### PR TITLE
Adding nova-compute machine constraints root-disk=80G

### DIFF
--- a/openstack/tools/charmed_openstack_functest_runner.sh
+++ b/openstack/tools/charmed_openstack_functest_runner.sh
@@ -218,11 +218,12 @@ if $MODIFY_BUNDLE_CONSTRAINTS; then
     for f in tests/bundles/*.yaml; do
         # Dont do this if the test does not have nova-compute
         if $(grep -q "nova-compute:" $f); then
-            if [[ $(yq '.applications' $f) = null ]]; then
-                yq -i '.services.nova-compute.constraints="root-disk=80G mem=8G"' $f
-            else
-                yq -i '.applications.nova-compute.constraints="root-disk=80G mem=8G"' $f
-            fi
+            # Taking nova-compute machines and add root-disk=80G to machine constraints
+            MACHINES=($(yq eval '(.services.nova-compute.to[] // .applications.nova-compute.to[])' "$f"))
+
+            for MACHINE in "${MACHINES[@]}"; do
+                yq eval -i ".machines[\"${MACHINE}\"].constraints = \"root-disk=80G mem=8G\"" "$f"
+            done
         fi
     done
     )


### PR DESCRIPTION
Current code that adding root-disk=80G to nova-compute application definition is not properly working with charm-manila-ganesha and with 'services' bundle entity

I assume that 'services' is old entity which doesn't support constraints while 'applications' does

I upload this patch to add root-disk to machine constraints instead for compatability.